### PR TITLE
chore: add dependency

### DIFF
--- a/packages/mask-ssn/sdf-package.yaml
+++ b/packages/mask-ssn/sdf-package.yaml
@@ -10,7 +10,7 @@ functions:
     operator: map
     dependencies:
       - name: regex
-        version: 1.11
+        version: "1.11"
     inputs:
       - name: text
         type: string

--- a/packages/mask-ssn/sdf-package.yaml
+++ b/packages/mask-ssn/sdf-package.yaml
@@ -8,6 +8,9 @@ meta:
 functions:
   mask-ssn:
     operator: map
+    dependencies:
+      - name: regex
+        version: 1.11
     inputs:
       - name: text
         type: string


### PR DESCRIPTION
currently nightly test is failing due to this dependency not been added to the `Cargo.toml` on `sdf update`